### PR TITLE
Fix built-in node module resolution

### DIFF
--- a/_test/pathTest.ts
+++ b/_test/pathTest.ts
@@ -1,0 +1,1 @@
+// Dummy file to test path resolver

--- a/src/PathResolver.test.ts
+++ b/src/PathResolver.test.ts
@@ -148,4 +148,32 @@ export default class PathResolverTest extends BaseTest {
 			t.fail('Got the wrong type of error back')
 		}
 	}
+
+	@test('Test core module resolution')
+	protected static async testCoreModuleResolution(
+		t: ExecutionContext<IContext>
+	) {
+		const resolver = new PathResolver({
+			enable: false,
+			cwd: path.join(__dirname, '..', '_test'),
+			extensions: ['.txt']
+		})
+
+		t.is(resolver.resolvePath('vm'), 'vm')
+	}
+
+	@test('Test absolute path resolution')
+	protected static async testAbsolutePathResolution(
+		t: ExecutionContext<IContext>
+	) {
+		const expected = path.resolve(__dirname, '..', '_test', 'pathTest.ts')
+
+		const resolver = new PathResolver({
+			enable: false,
+			cwd: path.join(__dirname, '..', 'register'),
+			extensions: ['.ts']
+		})
+
+		t.is(resolver.resolvePath(expected), expected)
+	}
 }

--- a/src/PathResolver.ts
+++ b/src/PathResolver.ts
@@ -178,6 +178,13 @@ export default class PathResolver {
 			return this.pathCache[request]
 		}
 
+		// Check if it's a core node module
+		// Is it a core node module?
+		const coreModule = coreModuleLoader.builtinModules.find(m => m === request)
+		if (coreModule) {
+			return request
+		}
+
 		let foundMatch = false
 		const attemptedPaths: string[] = []
 		const pathPatterns = Object.keys(this.replacePaths)


### PR DESCRIPTION
Path resolver was failing when importing a built-in node module like `vm`. This PR adds a check for those instead of throwing an error